### PR TITLE
Version Selection

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 
-use crate::github::{Release, Tag};
+use crate::github::{Release, ReleaseAndTag, Tag};
 
 // Application state shared between UI thread and update thread
 #[derive(Clone)]
@@ -16,6 +16,9 @@ pub struct AppState {
     current_version: Option<String>,
     nextui_release: Option<Release>,
     nextui_tag: Option<Tag>,
+    nextui_releases_and_tags: Options<Vec<ReleaseAndTag>>,
+    nextui_releases_and_tags_index: Option<usize>,
+    release_selection_menu: bool,
     current_operation: Option<String>,
     progress: Option<Progress>,
     error: Option<String>,
@@ -40,6 +43,9 @@ impl AppStateManager {
                 current_version: None,
                 nextui_release: None,
                 nextui_tag: None,
+                nextui_releases_and_tags: None,
+                nextui_releases_and_tags_index: None,
+                release_selection_menu: false,
                 current_operation: None,
                 progress: None,
                 error: None,
@@ -93,6 +99,18 @@ impl AppStateManager {
         self.state.lock().nextui_tag.clone()
     }
 
+    pub fn nextui_releases_and_tags(&self) -> Option<Vec<ReleaseAndTag>> {
+        self.state.lock().nextui_releases_and_tags.clone()
+    }
+
+    pub fn nextui_releases_and_tags_index(&self) -> Option<usize> {
+        self.state.lock().nextui_releases_and_tags_index.clone()
+    }
+
+    pub fn release_selection_menu(&self) -> bool {
+        self.state.lock().release_selection_menu
+    }
+
     // Setter methods
     pub fn set_submenu(&self, submenu: Submenu) {
         self.state.lock().submenu = submenu;
@@ -128,6 +146,18 @@ impl AppStateManager {
 
     pub fn set_nextui_tag(&self, tag: Option<Tag>) {
         self.state.lock().nextui_tag = tag;
+    }
+
+    pub fn set_nextui_releases_and_tags(&self, releases_and_tags: Option<Vec<ReleaseAndTag>>) {
+        self.state.lock().nextui_releases_and_tags = releases_and_tags;
+    }
+
+    pub fn set_nextui_releases_and_tags_index(&self, releases_and_tags_index: Option<usize>) {
+        self.state.lock().nextui_releases_and_tags_index = releases_and_tags_index;
+    }
+
+    pub fn set_release_selection_menu(&self, release_selection_menu: bool) {
+        self.state.lock().release_selection_menu = release_selection_menu;
     }
 
     // Combined operations

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -19,6 +19,7 @@ pub struct AppState {
     nextui_releases_and_tags: Option<Vec<ReleaseAndTag>>,
     nextui_releases_and_tags_index: Option<usize>,
     release_selection_menu: bool,
+    release_selection_confirmed: bool,
     current_operation: Option<String>,
     progress: Option<Progress>,
     error: Option<String>,
@@ -46,6 +47,7 @@ impl AppStateManager {
                 nextui_releases_and_tags: None,
                 nextui_releases_and_tags_index: None,
                 release_selection_menu: false,
+                release_selection_confirmed: false,
                 current_operation: None,
                 progress: None,
                 error: None,
@@ -111,6 +113,10 @@ impl AppStateManager {
         self.state.lock().release_selection_menu
     }
 
+    pub fn release_selection_confirmed(&self) -> bool {
+        self.state.lock().release_selection_confirmed
+    }
+
     // Setter methods
     pub fn set_submenu(&self, submenu: Submenu) {
         self.state.lock().submenu = submenu;
@@ -158,6 +164,10 @@ impl AppStateManager {
 
     pub fn set_release_selection_menu(&self, release_selection_menu: bool) {
         self.state.lock().release_selection_menu = release_selection_menu;
+    }
+
+    pub fn set_release_selection_confirmed(&self, release_selection_confirmed: bool) {
+        self.state.lock().release_selection_confirmed = release_selection_confirmed;
     }
 
     // Combined operations

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -16,7 +16,7 @@ pub struct AppState {
     current_version: Option<String>,
     nextui_release: Option<Release>,
     nextui_tag: Option<Tag>,
-    nextui_releases_and_tags: Options<Vec<ReleaseAndTag>>,
+    nextui_releases_and_tags: Option<Vec<ReleaseAndTag>>,
     nextui_releases_and_tags_index: Option<usize>,
     release_selection_menu: bool,
     current_operation: Option<String>,

--- a/src/github.rs
+++ b/src/github.rs
@@ -22,3 +22,8 @@ pub struct Tag {
 pub struct Commit {
     pub sha: String,
 }
+
+pub struct ReleaseAndTag {
+    pub release: Release,
+    pub tag: Tag,
+}

--- a/src/github.rs
+++ b/src/github.rs
@@ -23,6 +23,7 @@ pub struct Commit {
     pub sha: String,
 }
 
+#[derive(Clone, Debug)]
 pub struct ReleaseAndTag {
     pub release: Release,
     pub tag: Tag,

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,13 +24,6 @@ fn main() -> Result<()> {
     // Initialize application state
     let app_state: &'static AppStateManager = Box::leak(Box::new(AppStateManager::new()));
 
-    // Self-update
-    let app_state_clone = app_state.clone();
-    thread::spawn(move || {
-        do_self_update(&app_state_clone);
-        do_nextui_release_check(&app_state_clone);
-    });
-
     // Get current NextUI version
     let version_file =
         std::fs::read_to_string(SDCARD_ROOT.to_owned() + ".system/version.txt").unwrap_or_default();
@@ -39,6 +32,13 @@ fn main() -> Result<()> {
         .nth(1)
         .map(std::borrow::ToOwned::to_owned);
     app_state.set_current_version(current_sha);
+
+    // Self-update
+    let app_state_clone = app_state.clone();
+    thread::spawn(move || {
+        do_self_update(&app_state_clone);
+        do_nextui_release_check(&app_state_clone);
+    });
 
     run_ui(app_state)?;
 

--- a/src/update/fetching.rs
+++ b/src/update/fetching.rs
@@ -7,7 +7,6 @@ use reqwest::blocking::Client;
 use reqwest::IntoUrl;
 
 use crate::github::{Release, Tag};
-
 use crate::Result;
 
 const USER_AGENT: &str = concatcp!("NextUIUpdater/", env!("CARGO_PKG_VERSION"));
@@ -40,7 +39,7 @@ pub fn fetch_latest_release(repo: &str) -> Result<Release> {
     Ok(response.json()?)
 }
 
-pub fn fetch_all_releases(repo: &str) -> Result<Vec<Release>> {
+pub fn fetch_releases(repo: &str) -> Result<Vec<Release>> {
     let response = get_client()
         .get(format!(
             "https://api.github.com/repos/{repo}/releases?per_page=50"
@@ -55,9 +54,9 @@ pub fn fetch_all_releases(repo: &str) -> Result<Vec<Release>> {
     Ok(response.json()?)
 }
 
-pub fn fetch_tag(repo: &str, tag: &str) -> Result<Tag> {
+pub fn fetch_tags(repo: &str) -> Result<Vec<Tag>> {
     let response = get_client()
-        .get(format!("https://api.github.com/repos/{repo}/tags"))
+        .get(format!("https://api.github.com/repos/{repo}/tags?per_page=70"))
         .header("User-Agent", USER_AGENT)
         .send()?;
 
@@ -67,9 +66,7 @@ pub fn fetch_tag(repo: &str, tag: &str) -> Result<Tag> {
 
     let tags: Vec<Tag> = response.json()?;
 
-    let tag = tags.iter().find(|t| t.name == tag).ok_or("Tag not found")?;
-
-    Ok(tag.clone())
+    Ok(tags.clone())
 }
 
 pub fn download<U: IntoUrl>(url: U, progress_cb: impl Fn(f32)) -> Result<Bytes> {

--- a/src/update/fetching.rs
+++ b/src/update/fetching.rs
@@ -42,7 +42,7 @@ pub fn fetch_latest_release(repo: &str) -> Result<Release> {
 pub fn fetch_releases(repo: &str) -> Result<Vec<Release>> {
     let response = get_client()
         .get(format!(
-            "https://api.github.com/repos/{repo}/releases?per_page=50"
+            "https://api.github.com/repos/{repo}/releases?per_page=100"
         ))
         .header("User-Agent", USER_AGENT)
         .send()?;
@@ -56,7 +56,7 @@ pub fn fetch_releases(repo: &str) -> Result<Vec<Release>> {
 
 pub fn fetch_tags(repo: &str) -> Result<Vec<Tag>> {
     let response = get_client()
-        .get(format!("https://api.github.com/repos/{repo}/tags?per_page=70"))
+        .get(format!("https://api.github.com/repos/{repo}/tags?per_page=100"))
         .header("User-Agent", USER_AGENT)
         .send()?;
 

--- a/src/update/fetching.rs
+++ b/src/update/fetching.rs
@@ -40,6 +40,21 @@ pub fn fetch_latest_release(repo: &str) -> Result<Release> {
     Ok(response.json()?)
 }
 
+pub fn fetch_all_releases(repo: &str) -> Result<Vec<Release>> {
+    let response = get_client()
+        .get(format!(
+            "https://api.github.com/repos/{repo}/releases?per_page=50"
+        ))
+        .header("User-Agent", USER_AGENT)
+        .send()?;
+
+    if !response.status().is_success() {
+        return Err(format!("GitHub API request failed: {}", response.status()).into());
+    }
+
+    Ok(response.json()?)
+}
+
 pub fn fetch_tag(repo: &str, tag: &str) -> Result<Tag> {
     let response = get_client()
         .get(format!("https://api.github.com/repos/{repo}/tags"))

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -1,9 +1,10 @@
 use crate::{
-    app_state::{AppStateManager, Progress},
+    app_state::{self, AppStateManager, Progress},
     Result, SDCARD_ROOT,
+    github::{ReleaseAndTag, Release},
 };
 use bytes::Bytes;
-use fetching::{download, fetch_latest_release, fetch_tag};
+use fetching::{download, fetch_latest_release, fetch_releases, fetch_tags};
 use regex::Regex;
 
 use std::{
@@ -126,36 +127,76 @@ pub fn self_update(app_state: &AppStateManager) -> Result<()> {
 pub fn do_nextui_release_check(app_state: &AppStateManager) {
     // Fetch latest release information
     app_state.start_operation("Fetching latest NextUI release...");
+    let repo = "LoveRetro/NextUI";
 
-    let latest_release = fetch_latest_release("LoveRetro/NextUI");
-
-    match &latest_release {
-        Ok(release) => {
-            app_state.set_nextui_release(Some(release.clone()));
-        }
-        Err(err) => {
-            println!("Release fetch failed: {:?}", err.source());
-            app_state.set_operation_failed(&format!("Release fetch failed: {err}"));
-        }
+    // Fetch latest releases information
+    app_state.start_operation("Fetching latest NextUI releases...");
+    let latest_releases = fetch_releases(repo);
+    if latest_releases.is_err() {
+        // Failed connection
+        let err = latest_releases.unwrap_err();
+        println!("Releases fetch failed: {:?}", err.source());
+        app_state.set_operation_failed(&format!("Releases fetch failed: {err}"));
+        return err;
     }
-
-    if latest_release.is_err() {
-        return;
+    let latest_releases = latest_releases.unwrap();
+    if latest_releases.is_empty() {
+        // Connected, but no results
+        println!("Releases fetch returned 0 releases");
+        app_state.set_operation_failed("Releases fetch returned 0 releases");
+        return Err(format!("Releases fetch returned 0 releases").into());
     }
-    let latest_release = latest_release.unwrap();
 
     // Fetch latest tag information
-    app_state.start_operation("Fetching latest NextUI tag...");
+    app_state.start_operation("Fetching latest NextUI tags...");
+    let latest_tags = fetch_tags(repo);
+    if latest_tags.is_err() {
+        // Failed connection
+        let err = latest_tags.unwrap_err();
+        println!("Tags fetch failed: {:?}", err.source());
+        app_state.set_operation_failed(&format!("Tags fetch failed: {err}"));
+        return err;
+    }
+    let latest_tags = latest_tags.unwrap();
+    if latest_tags.is_empty() {
+        // Connected, but no results
+        println!("Tags fetch returned 0 tags");
+        app_state.set_operation_failed("Tags fetch returned 0 tags");
+        return Err(format!("Tags fetch returned 0 releases").into());;
+    }
 
-    let latest_tag = fetch_tag("LoveRetro/NextUI", &latest_release.tag_name);
-    match latest_tag {
-        Ok(tag) => {
-            app_state.set_nextui_tag(Some(tag.clone()));
+    // Build ReleaseAndTag list for app state
+    let mut releases_and_tags: Vec<ReleaseAndTag>;
+    let check_latest_release = true;
+    let current_tag = app_state.current_version().unwrap_or("");
+    let current_tag_found = false;
+    for (release_index, release) in latest_releases.iter().enumerate() {
+        if let Some(tag_index) = latest_tags.iter().position(|tag| tag.name == release.tag_name) {
+            releases_and_tags.push(ReleaseAndTag { release: (release), tag: (latest_tags[tag_index]) });
+            if latest_tags[tag_index].commit.sha.starts_with(current_tag) {
+                // set release selector starting index
+                app_state.set_nextui_releases_and_tags_index(tag_index);
+            }
+            latest_tags.remove(tag_index);
+            if check_latest_release {
+                check_latest_release = false;
+            }
+            continue;
         }
-        Err(err) => {
-            println!("Tag fetch failed: {:?}", err.source());
-            app_state.set_operation_failed(&format!("Tag fetch failed: {err}"));
+        if check_latest_release {
+            // Failed to find a match for the first release
+            println!("Latest release has no matching tag: {:?}", release.tag_name);
+            app_state.set_operation_failed(&format!("Latest release has no matching tag: {:?}", release.tag_name));
+            return Err(format!("Latest release has no matching tag: {:?}", release.tag_name).into());;
         }
+    }
+
+    // Save collected values to app state
+    app_state.set_nextui_release(Some(releases_and_tags[0].release.clone()));
+    app_state.set_nextui_tag(Some(releases_and_tags[0].tag.clone()));
+    app_state.set_nextui_releases_and_tags(Some(releases_and_tags.clone()));
+    if !current_tag_found {
+        app_state.set_nextui_releases_and_tags_index(0);
     }
 
     app_state.finish_operation();
@@ -189,7 +230,7 @@ pub fn do_update(app_state: &'static AppStateManager, full: bool) {
 }
 
 pub fn update_nextui(app_state: &AppStateManager, full: bool) -> Result<()> {
-    let release = {
+    let mut release = {
         app_state.start_operation("Downloading update...");
 
         app_state
@@ -197,6 +238,11 @@ pub fn update_nextui(app_state: &AppStateManager, full: bool) -> Result<()> {
             .clone()
             .ok_or("No release found")?
     };
+    if app_state.release_selection_menu() {
+        let index = app_state.nextui_releases_and_tags_index().ok_or(0)?;
+        let relase_and_tag_vector = app_state.nextui_releases_and_tags().ok_or("No release found")?;
+        release = relase_and_tag_vector[index].release;
+    }
 
     let assets = release.assets;
     let asset = assets


### PR DESCRIPTION
- Added new option X to open version selector from primary "latest version" screen
- Added a warning landing screen for version selector to indicate that downgrading is not fully supported by NextUI
- Added the version selector after warning confirmation allowing for scrolling left/right through different available releases. Offers up to the most recent 100 releases (paired with the 100 most recent tags)